### PR TITLE
Add a simple `echo` command to tmux

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -86,6 +86,7 @@ dist_tmux_SOURCES = \
 	cmd-display-menu.c \
 	cmd-display-message.c \
 	cmd-display-panes.c \
+	cmd-echo.c \
 	cmd-find-window.c \
 	cmd-find.c \
 	cmd-if-shell.c \

--- a/cmd-echo.c
+++ b/cmd-echo.c
@@ -1,0 +1,31 @@
+#include <sys/types.h>
+
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "tmux.h"
+
+static enum cmd_retval	cmd_echo_exec(struct cmd *, struct cmdq_item *);
+
+const struct cmd_entry cmd_echo_entry = {
+	.name = "echo",
+	.alias = NULL,
+
+	.args = { "", 1, 1, NULL },
+	.usage = "[message-to-echo]",
+
+	.flags = 0,
+	.exec = cmd_echo_exec
+};
+
+static enum cmd_retval cmd_echo_exec(struct cmd *self, struct cmdq_item *item)
+{
+	struct args *args = cmd_get_args(self);
+	const char *s = args_string(args, 0);
+
+	if(s == NULL)
+		return (CMD_RETURN_ERROR);
+
+	cmdq_print(item, "%s", s);
+	return (CMD_RETURN_NORMAL);
+}

--- a/cmd.c
+++ b/cmd.c
@@ -48,6 +48,7 @@ extern const struct cmd_entry cmd_display_message_entry;
 extern const struct cmd_entry cmd_display_popup_entry;
 extern const struct cmd_entry cmd_display_panes_entry;
 extern const struct cmd_entry cmd_down_pane_entry;
+extern const struct cmd_entry cmd_echo_entry;
 extern const struct cmd_entry cmd_find_window_entry;
 extern const struct cmd_entry cmd_has_session_entry;
 extern const struct cmd_entry cmd_if_shell_entry;
@@ -141,6 +142,7 @@ const struct cmd_entry *cmd_table[] = {
 	&cmd_display_message_entry,
 	&cmd_display_popup_entry,
 	&cmd_display_panes_entry,
+	&cmd_echo_entry,
 	&cmd_find_window_entry,
 	&cmd_has_session_entry,
 	&cmd_if_shell_entry,


### PR DESCRIPTION
This patch adds a simple command `echo` to tmux. The new command is intended to demonstrate the basic steps in adding a new command to tmux.